### PR TITLE
fix partial commit

### DIFF
--- a/src/main/java/cn/leancloud/kafka/consumer/AbstractRecommitAwareCommitPolicy.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/AbstractRecommitAwareCommitPolicy.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.TopicPartition;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 abstract class AbstractRecommitAwareCommitPolicy<K, V> extends AbstractCommitPolicy<K, V> {
     private final Duration recommitInterval;
@@ -21,10 +22,39 @@ abstract class AbstractRecommitAwareCommitPolicy<K, V> extends AbstractCommitPol
         updateNextRecommitTime(System.nanoTime());
     }
 
-    Map<TopicPartition, OffsetAndMetadata> offsetsForRecommit() {
+    @Override
+    public final Set<TopicPartition> tryCommit(boolean noPendingRecords) {
+        if (needRecommit()) {
+            commitSyncWithRetry(offsetsForRecommit());
+            updateNextRecommitTime();
+        }
+        return tryCommit0(noPendingRecords);
+    }
+
+    abstract Set<TopicPartition> tryCommit0(boolean noPendingRecords);
+
+    void updateNextRecommitTime() {
+        updateNextRecommitTime(System.nanoTime());
+    }
+
+    @VisibleForTesting
+    void updateNextRecommitTime(long currentNanos) {
+        nextRecommitNanos = currentNanos + recommitInterval.toNanos();
+    }
+
+    @VisibleForTesting
+    long nextRecommitNanos() {
+        return nextRecommitNanos;
+    }
+
+    private boolean needRecommit() {
+        return System.nanoTime() >= nextRecommitNanos;
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> offsetsForRecommit() {
         assert needRecommit() : "current nanos: " + System.nanoTime() + " nextRecommitNanos:" + nextRecommitNanos;
 
-        final Map<TopicPartition, OffsetAndMetadata> ret = new HashMap<>(completedTopicOffsets);
+        final Map<TopicPartition, OffsetAndMetadata> ret = new HashMap<>();
         for (TopicPartition partition : consumer.assignment()) {
             final OffsetAndMetadata offset = consumer.committed(partition);
             if (offset != null) {
@@ -33,22 +63,5 @@ abstract class AbstractRecommitAwareCommitPolicy<K, V> extends AbstractCommitPol
         }
 
         return ret;
-    }
-
-    boolean needRecommit() {
-        return System.nanoTime() >= nextRecommitNanos;
-    }
-
-    void updateNextRecommitTime() {
-        updateNextRecommitTime(System.nanoTime());
-    }
-
-    @VisibleForTesting
-    long nextRecommitNanos() {
-        return nextRecommitNanos;
-    }
-
-    private void updateNextRecommitTime(long currentNanos) {
-        nextRecommitNanos = currentNanos + recommitInterval.toNanos();
     }
 }

--- a/src/main/java/cn/leancloud/kafka/consumer/CommitPolicy.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/CommitPolicy.java
@@ -3,6 +3,7 @@ package cn.leancloud.kafka.consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Set;
 
 interface CommitPolicy<K, V> {
@@ -43,5 +44,12 @@ interface CommitPolicy<K, V> {
      *
      * @return those {@link TopicPartition}s which have no pending {@code ConsumerRecord}s
      */
-    Set<TopicPartition> syncPartialCommit();
+    Set<TopicPartition> partialCommitSync();
+
+    /**
+     * Revoke internal states for some partitions.
+     *
+     * @param partitions which was revoked from consumer
+     */
+    void revokePartitions(Collection<TopicPartition> partitions);
 }

--- a/src/main/java/cn/leancloud/kafka/consumer/CompletedOffsets.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/CompletedOffsets.java
@@ -1,0 +1,47 @@
+package cn.leancloud.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+
+import java.util.PriorityQueue;
+
+class CompletedOffsets {
+    private final PriorityQueue<Long> outOfOrderQueue;
+    private long committedOffset;
+    private long nextOffsetToCommit;
+
+    CompletedOffsets(long lastCommittedOffset) {
+        this.committedOffset = lastCommittedOffset;
+        this.nextOffsetToCommit = lastCommittedOffset + 1;
+        this.outOfOrderQueue = new PriorityQueue<>();
+    }
+
+    long nextOffsetToCommit() {
+        return nextOffsetToCommit;
+    }
+
+    void addCompleteOffset(long offset) {
+        if (offset == nextOffsetToCommit) {
+            ++nextOffsetToCommit;
+
+            while (!outOfOrderQueue.isEmpty() && outOfOrderQueue.peek() == nextOffsetToCommit) {
+                outOfOrderQueue.poll();
+                ++nextOffsetToCommit;
+            }
+        } else if (offset > nextOffsetToCommit) {
+            outOfOrderQueue.add(offset);
+        }
+    }
+
+    boolean hasOffsetToCommit() {
+        return committedOffset < nextOffsetToCommit - 1;
+    }
+
+    OffsetAndMetadata getOffsetToCommit() {
+        return new OffsetAndMetadata(nextOffsetToCommit);
+    }
+
+    void updateCommittedOffset(long committedOffset) {
+        assert committedOffset > this.committedOffset : "old:" + this.committedOffset + " new:" + committedOffset;
+        this.committedOffset = committedOffset;
+    }
+}

--- a/src/main/java/cn/leancloud/kafka/consumer/Fetcher.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/Fetcher.java
@@ -142,7 +142,7 @@ final class Fetcher<K, V> implements Runnable, Closeable {
                 unsubscribedStatus = UnsubscribedStatus.ERROR;
                 markClosed();
                 break;
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 if (ex instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
@@ -259,7 +259,7 @@ final class Fetcher<K, V> implements Runnable, Closeable {
         long shutdownTimeout = 0L;
         try {
             shutdownTimeout = waitPendingFuturesDone();
-            policy.syncPartialCommit();
+            policy.partialCommitSync();
             pendingFutures.clear();
         } catch (Exception ex) {
             logger.error("Graceful shutdown got unexpected exception", ex);

--- a/src/main/java/cn/leancloud/kafka/consumer/LcKafkaConsumer.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/LcKafkaConsumer.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.min;
@@ -29,6 +30,8 @@ import static java.util.Objects.requireNonNull;
  * @param <V> the type of value for records consumed from Kafka
  */
 public final class LcKafkaConsumer<K, V> implements Closeable {
+    private static final AtomicInteger lastFetcherThreadId = new AtomicInteger();
+
     enum State {
         INIT(0),
         SUBSCRIBED(1),
@@ -210,13 +213,13 @@ public final class LcKafkaConsumer<K, V> implements Closeable {
         final String firstTopic = topics.iterator().next();
         String postfix = firstTopic.substring(0, min(50, firstTopic.length()));
         postfix += topics.size() > 1 || firstTopic.length() > 50 ? "..." : "";
-        return "kafka-fetcher-for-" + postfix;
+        return "kafka-fetcher-for-" + postfix + "-" + lastFetcherThreadId.incrementAndGet();
     }
 
     private String fetcherThreadName(Pattern pattern) {
         final String patternInString = pattern.toString();
         String postfix = patternInString.substring(0, min(50, patternInString.length()));
         postfix += patternInString.length() > 50 ? "..." : "";
-        return "kafka-fetcher-for-" + postfix;
+        return "kafka-fetcher-for-" + postfix + "-" + lastFetcherThreadId.incrementAndGet();
     }
 }

--- a/src/main/java/cn/leancloud/kafka/consumer/NoOpCommitPolicy.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/NoOpCommitPolicy.java
@@ -3,6 +3,7 @@ package cn.leancloud.kafka.consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -30,7 +31,12 @@ final class NoOpCommitPolicy<K, V> implements CommitPolicy<K, V> {
     }
 
     @Override
-    public Set<TopicPartition> syncPartialCommit() {
+    public Set<TopicPartition> partialCommitSync() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public void revokePartitions(Collection<TopicPartition> partitions) {
+
     }
 }

--- a/src/main/java/cn/leancloud/kafka/consumer/PartialAsyncCommitPolicy.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/PartialAsyncCommitPolicy.java
@@ -10,11 +10,14 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.*;
 
+import static java.util.Collections.emptySet;
+
 final class PartialAsyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPolicy<K, V> {
     private static final Logger logger = LoggerFactory.getLogger(PartialAsyncCommitPolicy.class);
 
     private final int maxPendingAsyncCommits;
-    private final OffsetCommitCallback callback;
+    private final OffsetCommitCallback fullCommitCallback;
+    private final OffsetCommitCallback partialCommitCallback;
     private final Map<TopicPartition, OffsetAndMetadata> pendingAsyncCommitOffset;
     private int pendingAsyncCommitCounter;
     private boolean forceSync;
@@ -26,32 +29,47 @@ final class PartialAsyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPo
                              int maxPendingAsyncCommits) {
         super(consumer, syncCommitRetryInterval, maxAttemptsForEachSyncCommit, forceWholeCommitInterval);
         this.maxPendingAsyncCommits = maxPendingAsyncCommits;
-        this.callback = new AsyncCommitCallback();
+        this.fullCommitCallback = new AsyncFullCommitCallback();
+        this.partialCommitCallback = new AsyncPartialCommitCallback();
         this.pendingAsyncCommitOffset = new HashMap<>();
     }
 
     @Override
-    public Set<TopicPartition> tryCommit(boolean noPendingRecords) {
-        final boolean syncCommit = forceSync || pendingAsyncCommitCounter >= maxPendingAsyncCommits;
-        final Map<TopicPartition, OffsetAndMetadata> offsets = offsetsForPartialCommit(syncCommit);
-
-        if (offsets.isEmpty()) {
-            return Collections.emptySet();
-        } else {
-            final Set<TopicPartition> partitions = getCompletedPartitions(noPendingRecords);
-            if (syncCommit) {
-                commitSync(offsets);
-                pendingAsyncCommitOffset.clear();
-                pendingAsyncCommitCounter = 0;
-                forceSync = false;
-                clearCachedCompletedPartitionsRecords(partitions, noPendingRecords);
-            } else {
-                ++pendingAsyncCommitCounter;
-                consumer.commitAsync(offsets, callback);
-                pendingAsyncCommitOffset.putAll(offsets);
-            }
-            return partitions;
+    Set<TopicPartition> tryCommit0(boolean noPendingRecords) {
+        if (forceSync) {
+            return tryCommitOnForceSync(noPendingRecords);
         }
+
+        if (noTopicOffsetsToCommit()) {
+            return emptySet();
+        }
+
+        if (noPendingRecords) {
+            return fullCommit();
+        }
+
+        final Set<TopicPartition> completePartitions;
+        if (useSyncCommit()) {
+            completePartitions = partialCommitSync();
+            pendingAsyncCommitOffset.clear();
+            pendingAsyncCommitCounter = 0;
+        } else {
+            final Map<TopicPartition, OffsetAndMetadata> offsets = completedTopicOffsetsToCommit();
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : pendingAsyncCommitOffset.entrySet()) {
+                offsets.remove(entry.getKey(), entry.getValue());
+            }
+
+            if (offsets.isEmpty()) {
+                return emptySet();
+            }
+
+            ++pendingAsyncCommitCounter;
+
+            completePartitions = partitionsToSafeResume(offsets);
+            pendingAsyncCommitOffset.putAll(offsets);
+            consumer.commitAsync(offsets, partialCommitCallback);
+        }
+        return completePartitions;
     }
 
     @VisibleForTesting
@@ -60,28 +78,65 @@ final class PartialAsyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPo
     }
 
     @VisibleForTesting
+    void setPendingAsyncCommitCount(int count) {
+        pendingAsyncCommitCounter = count;
+    }
+
+    @VisibleForTesting
+    Map<TopicPartition, OffsetAndMetadata> pendingAsyncCommitOffset() {
+        return pendingAsyncCommitOffset;
+    }
+
+    @VisibleForTesting
     boolean forceSync() {
         return forceSync;
     }
 
-    private Map<TopicPartition, OffsetAndMetadata> offsetsForPartialCommit(boolean syncCommit) {
-        final Map<TopicPartition, OffsetAndMetadata> offsets;
-        if (needRecommit()) {
-            offsets = offsetsForRecommit();
-            // we tolerate the commit failure when using async commit
-            updateNextRecommitTime();
-        } else if (syncCommit) {
-            offsets = completedTopicOffsets;
-        } else {
-            offsets = new HashMap<>(completedTopicOffsets);
-            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : pendingAsyncCommitOffset.entrySet()) {
-                offsets.remove(entry.getKey(), entry.getValue());
-            }
-        }
-        return offsets;
+    @VisibleForTesting
+    void setForceSync(boolean forceSync) {
+        this.forceSync = forceSync;
     }
 
-    private class AsyncCommitCallback implements OffsetCommitCallback {
+    private Set<TopicPartition> tryCommitOnForceSync(boolean noPendingRecords) {
+        final Set<TopicPartition> completedPartitions;
+        if (noPendingRecords) {
+            completedPartitions = fullCommitSync();
+            updateNextRecommitTime();
+        } else {
+            completedPartitions = partialCommitSync();
+        }
+        pendingAsyncCommitOffset.clear();
+        pendingAsyncCommitCounter = 0;
+        forceSync = false;
+        return completedPartitions;
+    }
+
+    private boolean useSyncCommit() {
+        return pendingAsyncCommitCounter >= maxPendingAsyncCommits;
+    }
+
+    private Set<TopicPartition> fullCommit() {
+        final Set<TopicPartition> completePartitions = partitionsForAllRecordsStates();
+        if (useSyncCommit()) {
+            commitSyncWithRetry();
+            pendingAsyncCommitCounter = 0;
+        } else {
+            ++pendingAsyncCommitCounter;
+            consumer.commitAsync(fullCommitCallback);
+        }
+        // no matter sync or async commit we are using, we always
+        // commit all assigned offsets, so we can update recommit time here safely. And
+        // we don't mind that if the async commit request failed, we tolerate this situation
+        updateNextRecommitTime();
+
+        // we can clear records states even though the async commit may fail. because if
+        // it did failed, we will do a sync commit on next try commit
+        clearAllProcessingRecordStates();
+        pendingAsyncCommitOffset.clear();
+        return completePartitions;
+    }
+
+    private class AsyncFullCommitCallback implements OffsetCommitCallback {
         @Override
         public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
             --pendingAsyncCommitCounter;
@@ -92,13 +147,24 @@ final class PartialAsyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPo
                 logger.warn("Failed to commit offset: " + offsets + " asynchronously", exception);
                 forceSync = true;
             } else {
-                for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
-                    topicOffsetHighWaterMark.remove(entry.getKey(), entry.getValue().offset());
-                    // we don't clear pendingAsyncCommitOffset here
-                    // because they are cleared on sync commit which occurs every maxPendingAsyncCommits async commits
-                    // todo: maybe we don't need to clean completedTopicOffsets too
-                    completedTopicOffsets.remove(entry.getKey(), entry.getValue());
-                }
+                clearProcessingRecordStatesForCompletedPartitions(offsets);
+            }
+        }
+    }
+
+    private class AsyncPartialCommitCallback implements OffsetCommitCallback {
+        @Override
+        public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
+            --pendingAsyncCommitCounter;
+            assert pendingAsyncCommitCounter >= 0 : "actual: " + pendingAsyncCommitCounter;
+            if (exception != null) {
+                // if last async commit is failed, we do not clean cached completed offsets and let next
+                // commit be a sync commit so all the complete offsets will be committed at that time
+                logger.warn("Failed to commit offset: " + offsets + " asynchronously", exception);
+                forceSync = true;
+            } else {
+                updatePartialCommittedOffsets(offsets);
+                clearProcessingRecordStatesForCompletedPartitions(offsets);
             }
         }
     }

--- a/src/main/java/cn/leancloud/kafka/consumer/PartialSyncCommitPolicy.java
+++ b/src/main/java/cn/leancloud/kafka/consumer/PartialSyncCommitPolicy.java
@@ -1,13 +1,12 @@
 package cn.leancloud.kafka.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
+
+import static java.util.Collections.emptySet;
 
 final class PartialSyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPolicy<K, V> {
     PartialSyncCommitPolicy(Consumer<K, V> consumer,
@@ -18,28 +17,17 @@ final class PartialSyncCommitPolicy<K, V> extends AbstractRecommitAwareCommitPol
     }
 
     @Override
-    public Set<TopicPartition> tryCommit(boolean noPendingRecords) {
-        final Map<TopicPartition, OffsetAndMetadata> offsets = offsetsForPartialCommit();
-        if (!offsets.isEmpty()) {
-            commitSync(offsets);
+    Set<TopicPartition> tryCommit0(boolean noPendingRecords) {
+        if (noTopicOffsetsToCommit()) {
+            return emptySet();
         }
 
-        if (completedTopicOffsets.isEmpty()) {
-            return Collections.emptySet();
-        } else {
-            final Set<TopicPartition> partitions = getCompletedPartitions(noPendingRecords);
-            clearCachedCompletedPartitionsRecords(partitions, noPendingRecords);
-            return partitions;
-        }
-    }
-
-    private Map<TopicPartition, OffsetAndMetadata> offsetsForPartialCommit() {
-        if (needRecommit()) {
-            final Map<TopicPartition, OffsetAndMetadata> offsets = offsetsForRecommit();
+        if (noPendingRecords) {
+            final Set<TopicPartition> completePartitions = fullCommitSync();
             updateNextRecommitTime();
-            return offsets;
-        } else {
-            return completedTopicOffsets;
+            return completePartitions;
         }
+
+        return partialCommitSync();
     }
 }

--- a/src/test/java/cn/leancloud/kafka/consumer/AbstractCommitPolicyTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/AbstractCommitPolicyTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static cn.leancloud.kafka.consumer.TestingUtils.*;
@@ -63,6 +64,8 @@ public class AbstractCommitPolicyTest {
                 .hasSize(1)
                 .containsOnlyKeys(partition(101))
                 .containsValue(1002L);
+        assertThat(policy.noCompletedOffsets()).isFalse();
+        assertThat(policy.noTopicOffsetsToCommit()).isTrue();
     }
 
     @Test
@@ -79,13 +82,16 @@ public class AbstractCommitPolicyTest {
                 .containsValues(1005L, 1003L, 1004L)
                 .extracting(partition(101))
                 .isEqualTo(1005L);
+        assertThat(policy.noCompletedOffsets()).isFalse();
+        assertThat(policy.noTopicOffsetsToCommit()).isTrue();
     }
 
     @Test
     public void testAddOneCompleteRecord() {
         ConsumerRecord<Object, Object> record = new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg);
+        policy.markPendingRecord(record);
         policy.markCompletedRecord(record);
-        assertThat(policy.completedTopicOffsets())
+        assertThat(policy.completedTopicOffsetsToCommit())
                 .hasSize(1)
                 .containsOnlyKeys(partition(101))
                 .containsValue(new OffsetAndMetadata(1002L));
@@ -93,18 +99,45 @@ public class AbstractCommitPolicyTest {
 
     @Test
     public void testAddSeveralCompleteRecord() {
-        policy.markCompletedRecord(new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg));
-        policy.markCompletedRecord(new ConsumerRecord<>(testingTopic, 102, 1002, defaultKey, defaultMsg));
-        policy.markCompletedRecord(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
-        policy.markCompletedRecord(new ConsumerRecord<>(testingTopic, 101, 1004, defaultKey, defaultMsg));
+        final List<ConsumerRecord<Object, Object>> records = new ArrayList<>();
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 102, 1002, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1004, defaultKey, defaultMsg));
 
-        assertThat(policy.completedTopicOffsets())
+        for (ConsumerRecord<Object, Object> record : records) {
+            policy.markPendingRecord(record);
+            policy.markCompletedRecord(record);
+        }
+
+        assertThat(policy.completedTopicOffsetsToCommit())
                 .hasSize(3)
-                .containsKeys(partition(101),
-                        partition(102), partition(103))
-                .containsValues(new OffsetAndMetadata(1003L), new OffsetAndMetadata(1004L), new OffsetAndMetadata(1005L))
+                .containsKeys(partition(101), partition(102), partition(103))
+                .containsValues(new OffsetAndMetadata(1003L), new OffsetAndMetadata(1004L), new OffsetAndMetadata(1002L))
                 .extracting(partition(101))
-                .isEqualTo(new OffsetAndMetadata(1005L));
+                // the second added record is not a consecutive record, so the offset is remains after it added
+                .isEqualTo(new OffsetAndMetadata(1002L));
+    }
+
+    @Test
+    public void testRevokePartitions() {
+        final List<ConsumerRecord<Object, Object>> records = new ArrayList<>();
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 102, 1002, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1004, defaultKey, defaultMsg));
+
+        for (ConsumerRecord<Object, Object> record : records) {
+            policy.markPendingRecord(record);
+            policy.markCompletedRecord(record);
+        }
+
+        policy.revokePartitions(toPartitions(IntStream.range(101, 103).boxed().collect(toList())));
+
+        assertThat(policy.completedTopicOffsetsToCommit())
+                .hasSize(1)
+                .containsOnlyKeys(partition(103))
+                .containsValue(new OffsetAndMetadata(1004L));
     }
 
     @Test
@@ -117,20 +150,12 @@ public class AbstractCommitPolicyTest {
         highWaterMark.add(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
         // not in complete records
         highWaterMark.add(new ConsumerRecord<>(testingTopic, 104, 1005, defaultKey, defaultMsg));
-        highWaterMark.add(new ConsumerRecord<>(testingTopic, 101, 1006, defaultKey, defaultMsg));
-        highWaterMark.add(new ConsumerRecord<>(testingTopic, 102, 1007, defaultKey, defaultMsg));
-        highWaterMark.add(new ConsumerRecord<>(testingTopic, 103, 1008, defaultKey, defaultMsg));
-        highWaterMark.add(new ConsumerRecord<>(testingTopic, 101, 1009, defaultKey, defaultMsg));
+        highWaterMark.add(new ConsumerRecord<>(testingTopic, 105, 1006, defaultKey, defaultMsg));
 
         final List<ConsumerRecord<Object, Object>> completeRecords = new ArrayList<>();
         completeRecords.add(new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg));
         completeRecords.add(new ConsumerRecord<>(testingTopic, 102, 1002, defaultKey, defaultMsg));
         completeRecords.add(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
-        completeRecords.add(new ConsumerRecord<>(testingTopic, 101, 1006, defaultKey, defaultMsg));
-        // greater than high water mark
-        completeRecords.add(new ConsumerRecord<>(testingTopic, 102, 1011, defaultKey, defaultMsg));
-        // partition not in high water mark records
-        completeRecords.add(new ConsumerRecord<>(testingTopic, 111, 2222, defaultKey, defaultMsg));
 
         for (ConsumerRecord<Object, Object> record : highWaterMark) {
             consumer.addRecord(record);
@@ -144,27 +169,45 @@ public class AbstractCommitPolicyTest {
 
         consumer.poll(0);
 
-        assertThat(policy.syncPartialCommit())
-                .hasSize(2)
-                .containsExactlyInAnyOrder(partition(102), partition(111));
-        assertThat(consumer.committed(partition(101))).isEqualTo(offset(1007L));
-        assertThat(consumer.committed(partition(102))).isEqualTo(offset(1012L));
+        assertThat(policy.partialCommitSync())
+                .hasSize(3)
+                .containsExactlyInAnyOrder(partition(103), partition(102), partition(101));
+        assertThat(consumer.committed(partition(101))).isEqualTo(offset(1002L));
+        assertThat(consumer.committed(partition(102))).isEqualTo(offset(1003L));
         assertThat(consumer.committed(partition(103))).isEqualTo(offset(1004L));
-        assertThat(consumer.committed(partition(111))).isEqualTo(offset(2223L));
 
-        assertThat(policy.completedTopicOffsets()).isEmpty();
+        assertThat(policy.completedTopicOffsetsToCommit()).isEmpty();
         assertThat(policy.topicOffsetHighWaterMark())
-                .hasSize(3)
-                .extracting(partition(101))
-                .isEqualTo(1010L);
-        assertThat(policy.topicOffsetHighWaterMark())
-                .hasSize(3)
-                .extracting(partition(103))
-                .isEqualTo(1009L);
-        assertThat(policy.topicOffsetHighWaterMark())
-                .hasSize(3)
-                .extracting(partition(104))
-                .isEqualTo(1006L);
+                .hasSize(2)
+                .containsEntry(partition(104), 1006L)
+                .containsEntry(partition(105), 1007L);
+    }
+
+    @Test
+    public void testFullCommit() {
+        final Consumer<Object, Object> mockedConsumer = mock(Consumer.class);
+        final Duration retryInterval = Duration.ofSeconds(1);
+        final int maxAttempts = 3;
+        policy = new TestingAbstractCommitPolicy(mockedConsumer, retryInterval, maxAttempts);
+        final List<ConsumerRecord<Object, Object>> records = new ArrayList<>();
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1001, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 102, 1002, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 103, 1003, defaultKey, defaultMsg));
+        records.add(new ConsumerRecord<>(testingTopic, 101, 1004, defaultKey, defaultMsg));
+
+        for (ConsumerRecord<Object, Object> record : records) {
+            policy.markPendingRecord(record);
+            policy.markCompletedRecord(record);
+        }
+
+        assertThat(policy.fullCommitSync())
+                .containsExactlyInAnyOrderElementsOf(
+                        records.stream()
+                                .map(record -> new TopicPartition(testingTopic, record.partition()))
+                                .collect(Collectors.toSet()));
+        verify(mockedConsumer, times(1)).commitSync();
+        assertThat(policy.noCompletedOffsets());
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
     }
 
     @Test
@@ -176,7 +219,7 @@ public class AbstractCommitPolicyTest {
         policy = new TestingAbstractCommitPolicy(mockedConsumer, retryInterval, maxAttempts);
 
         doThrow(exception).when(mockedConsumer).commitSync();
-        assertThatThrownBy(() -> policy.commitSync()).isSameAs(exception);
+        assertThatThrownBy(() -> policy.commitSyncWithRetry()).isSameAs(exception);
 
         verify(mockedConsumer, times(maxAttempts)).commitSync();
         assertThat(sleptTime).isEqualTo(retryInterval.multipliedBy(maxAttempts - 1).toMillis());
@@ -192,7 +235,7 @@ public class AbstractCommitPolicyTest {
         policy = new TestingAbstractCommitPolicy(mockedConsumer, retryInterval, maxAttempts);
 
         doThrow(exception).when(mockedConsumer).commitSync(offsets);
-        assertThatThrownBy(() -> policy.commitSync(offsets)).isSameAs(exception);
+        assertThatThrownBy(() -> policy.commitSyncWithRetry(offsets)).isSameAs(exception);
 
         verify(mockedConsumer, times(maxAttempts)).commitSync(offsets);
         assertThat(sleptTime).isEqualTo(retryInterval.multipliedBy(maxAttempts - 1).toMillis());
@@ -208,7 +251,7 @@ public class AbstractCommitPolicyTest {
 
         Thread.currentThread().interrupt();
         doThrow(exception).when(mockedConsumer).commitSync();
-        assertThatThrownBy(() -> policy.commitSync()).isSameAs(exception).satisfies(t -> {
+        assertThatThrownBy(() -> policy.commitSyncWithRetry()).isSameAs(exception).satisfies(t -> {
             final Throwable[] suppressed = t.getSuppressed();
             assertThat(suppressed.length).isEqualTo(1);
             assertThat(suppressed[0]).isInstanceOf(InterruptedException.class);

--- a/src/test/java/cn/leancloud/kafka/consumer/AbstractRecommitAwareCommitPolicyTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/AbstractRecommitAwareCommitPolicyTest.java
@@ -1,0 +1,63 @@
+package cn.leancloud.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static cn.leancloud.kafka.consumer.TestingUtils.*;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class AbstractRecommitAwareCommitPolicyTest {
+    private static class TestingPolicy extends AbstractRecommitAwareCommitPolicy<Object, Object> {
+        TestingPolicy(Consumer<Object, Object> consumer, Duration syncCommitRetryInterval, int maxAttemptsForEachSyncCommit, Duration recommitInterval) {
+            super(consumer, syncCommitRetryInterval, maxAttemptsForEachSyncCommit, recommitInterval);
+        }
+
+        @Override
+        Set<TopicPartition> tryCommit0(boolean noPendingRecords) {
+            return null;
+        }
+    }
+
+    private TestingPolicy policy;
+    private List<TopicPartition> partitions;
+
+    @Before
+    public void setUp() {
+        partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
+    }
+
+    @Test
+    public void testRecommit() {
+        final Consumer<Object, Object> consumer = mock(Consumer.class);
+        final List<ConsumerRecord<Object, Object>> prevRecords = prepareConsumerRecords(toPartitions(IntStream.range(0, 10).boxed().collect(toList())), 1, 10);
+        final Map<TopicPartition, OffsetAndMetadata> previousCommitOffsets = buildCommitOffsets(prevRecords);
+        final long now = System.nanoTime();
+
+        when(consumer.assignment()).thenReturn(new HashSet<>(partitions));
+        when(consumer.committed(any())).thenAnswer(invocation ->
+                previousCommitOffsets.get(invocation.getArgument(0))
+        );
+
+        policy = new TestingPolicy(consumer, Duration.ZERO, 3, Duration.ofMillis(200));
+
+        policy.updateNextRecommitTime(now - Duration.ofMillis(200).toNanos());
+        policy.tryCommit(true);
+
+        verify(consumer, times(1)).commitSync(previousCommitOffsets);
+        assertThat(policy.nextRecommitNanos()).isGreaterThan(now + Duration.ofMillis(200).toNanos());
+    }
+}

--- a/src/test/java/cn/leancloud/kafka/consumer/AsyncCommitPolicyTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/AsyncCommitPolicyTest.java
@@ -6,17 +6,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 import java.time.Duration;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.IntStream;
 
 import static cn.leancloud.kafka.consumer.TestingUtils.*;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -43,96 +38,54 @@ public class AsyncCommitPolicyTest {
     }
 
     @Test
-    public void testHavePendingRecords() {
+    public void testOnlyConsumedRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        assertThat(policy.tryCommit(false)).isEmpty();
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isNull();
+        }
+        assertThat(policy.noCompletedOffsets()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testOnlyPendingRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        addPendingRecordsInPolicy(policy, pendingRecords);
+        assertThat(policy.tryCommit(true)).isEmpty();
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isNull();
+        }
+        assertThat(policy.noTopicOffsetsToCommit()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isNotEmpty();
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testHasCompleteRecordsAndPendingRecords() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
         addCompleteRecordsInPolicy(policy, pendingRecords);
         assertThat(policy.tryCommit(false)).isEmpty();
         for (TopicPartition partition : partitions) {
             assertThat(consumer.committed(partition)).isNull();
         }
-        assertThat(policy.completedTopicOffsets()).isNotEmpty();
+        assertThat(policy.noCompletedOffsets()).isFalse();
         assertThat(policy.topicOffsetHighWaterMark()).isNotEmpty();
         assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
     }
 
     @Test
-    public void testNoCompleteRecords() {
-        final long nextRecommitNanos = policy.nextRecommitNanos();
-        assignPartitions(consumer, partitions, 0L);
-        generateConsumedRecords(consumer, partitions);
-        assertThat(policy.tryCommit(true)).isEmpty();
-        for (TopicPartition partition : partitions) {
-            assertThat(consumer.committed(partition)).isNull();
-        }
-        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
-    }
-
-    @Test
-    public void testSyncRecommit() throws Exception {
-        policy = new AsyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofMillis(200), defaultMaxPendingAsyncCommits);
-        long nextRecommitNanos = policy.nextRecommitNanos();
-        assignPartitions(consumer, toPartitions(range(0, 30).boxed().collect(toList())), 0L);
-
-        final List<ConsumerRecord<Object, Object>> prevRecords = generateConsumedRecords(consumer, toPartitions(range(0, 10).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> previousCommitOffsets = buildCommitOffsets(prevRecords);
-        addCompleteRecordsInPolicy(policy, prevRecords);
-        assertThat(policy.tryCommit(true))
-                .containsExactlyInAnyOrderElementsOf(toPartitions(range(0, 10).boxed().collect(toList())));
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-
-        Thread.sleep(200);
-        nextRecommitNanos = policy.nextRecommitNanos();
-        final List<ConsumerRecord<Object, Object>> newRecords = generateConsumedRecords(consumer, toPartitions(range(10, 20).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> newCommitOffsets = buildCommitOffsets(newRecords);
-        newCommitOffsets.putAll(previousCommitOffsets);
-
-        addCompleteRecordsInPolicy(policy, newRecords);
-        policy.setForceSync(true);
-        assertThat(policy.tryCommit(false)).isEmpty();
-        assertThat(policy.forceSync()).isFalse();
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : newCommitOffsets.entrySet()) {
-            assertThat(consumer.committed(entry.getKey())).isEqualTo(entry.getValue());
-        }
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-    }
-
-    @Test
-    public void testAsyncRecommit() throws Exception {
-        policy = new AsyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofMillis(200), defaultMaxPendingAsyncCommits);
-        long nextRecommitNanos = policy.nextRecommitNanos();
-        assignPartitions(consumer, toPartitions(range(0, 30).boxed().collect(toList())), 0L);
-
-        final List<ConsumerRecord<Object, Object>> prevRecords = generateConsumedRecords(consumer, toPartitions(range(0, 10).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> previousCommitOffsets = buildCommitOffsets(prevRecords);
-        addCompleteRecordsInPolicy(policy, prevRecords);
-        assertThat(policy.tryCommit(true))
-                .containsExactlyInAnyOrderElementsOf(toPartitions(range(0, 10).boxed().collect(toList())));
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-
-        Thread.sleep(200);
-        nextRecommitNanos = policy.nextRecommitNanos();
-        final List<ConsumerRecord<Object, Object>> newRecords = generateConsumedRecords(consumer, toPartitions(range(10, 20).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> newCommitOffsets = buildCommitOffsets(newRecords);
-        newCommitOffsets.putAll(previousCommitOffsets);
-
-        addCompleteRecordsInPolicy(policy, newRecords);
-        policy.setForceSync(false);
-        assertThat(policy.tryCommit(false)).isEmpty();
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : newCommitOffsets.entrySet()) {
-            assertThat(consumer.committed(entry.getKey())).isEqualTo(entry.getValue());
-        }
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-    }
-
-    @Test
-    public void testTryCommitAll() {
+    public void testTryCommitAllAsync() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
         addCompleteRecordsInPolicy(policy, pendingRecords);
         assertThat(policy.tryCommit(true)).containsExactlyInAnyOrderElementsOf(partitions);
         for (TopicPartition partition : partitions) {
             assertThat(consumer.committed(partition)).isEqualTo(new OffsetAndMetadata(2));
         }
-        assertThat(policy.completedTopicOffsets()).isEmpty();
+        // async commit callback called immediately when we call consumer.commitAsync()
+        // so processing record states was cleared
+        assertThat(policy.noCompletedOffsets()).isTrue();
         assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
         assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
     }
@@ -142,27 +95,30 @@ public class AsyncCommitPolicyTest {
         final Consumer<Object, Object> mockConsumer = Mockito.mock(Consumer.class);
         doNothing().when(mockConsumer).commitAsync(any());
 
-        int asyncCommitTimes = pendingRecords.size() - 1;
-        policy = new AsyncCommitPolicy<>(mockConsumer, Duration.ZERO, 3, Duration.ofHours(1), asyncCommitTimes);
+        final int maxAsyncCommitTimes = pendingRecords.size() - 1;
+        policy = new AsyncCommitPolicy<>(mockConsumer, Duration.ZERO, 3,
+                Duration.ofHours(1), maxAsyncCommitTimes);
 
-        for (ConsumerRecord<Object, Object> record : pendingRecords.subList(0, asyncCommitTimes)) {
+        final Set<TopicPartition> committedPartitions = new HashSet<>();
+        for (ConsumerRecord<Object, Object> record : pendingRecords.subList(0, maxAsyncCommitTimes)) {
             addCompleteRecordInPolicy(policy, record);
+            committedPartitions.add(new TopicPartition(record.topic(), record.partition()));
             assertThat(policy.tryCommit(true))
-                    .hasSize(1)
-                    .isEqualTo(Collections.singleton(new TopicPartition(record.topic(), record.partition())));
+                    .hasSize(committedPartitions.size())
+                    .containsExactlyInAnyOrderElementsOf(committedPartitions);
             assertThat(policy.forceSync()).isFalse();
         }
 
-        verify(mockConsumer, times(asyncCommitTimes)).commitAsync(any());
+        verify(mockConsumer, times(maxAsyncCommitTimes)).commitAsync(any());
         verify(mockConsumer, never()).commitSync();
-        assertThat(policy.pendingAsyncCommitCount()).isEqualTo(asyncCommitTimes);
+        assertThat(policy.pendingAsyncCommitCount()).isEqualTo(maxAsyncCommitTimes);
 
-        final ConsumerRecord<Object, Object> synCommitRecord = pendingRecords.get(asyncCommitTimes);
+        final ConsumerRecord<Object, Object> synCommitRecord = pendingRecords.get(maxAsyncCommitTimes);
         addCompleteRecordInPolicy(policy, synCommitRecord);
         assertThat(policy.tryCommit(true))
-                .hasSize(1)
-                .isEqualTo(Collections.singleton(new TopicPartition(synCommitRecord.topic(), synCommitRecord.partition())));
-        verify(mockConsumer, times(asyncCommitTimes)).commitAsync(any());
+                .hasSize(partitions.size())
+                .containsExactlyInAnyOrderElementsOf(partitions);
+        verify(mockConsumer, times(maxAsyncCommitTimes)).commitAsync(any());
         verify(mockConsumer, times(1)).commitSync();
         assertThat(policy.pendingAsyncCommitCount()).isZero();
     }
@@ -176,9 +132,7 @@ public class AsyncCommitPolicyTest {
 
         for (ConsumerRecord<Object, Object> record : pendingRecords) {
             addCompleteRecordInPolicy(policy, record);
-            assertThat(policy.tryCommit(true))
-                    .hasSize(1)
-                    .isEqualTo(Collections.singleton(new TopicPartition(record.topic(), record.partition())));
+            policy.tryCommit(true);
         }
 
         verify(mockConsumer, times(28)).commitAsync(any());
@@ -211,10 +165,13 @@ public class AsyncCommitPolicyTest {
         assertThat(policy.forceSync()).isTrue();
 
         final ConsumerRecord<Object, Object> syncRecord = pendingRecords.get(1);
+        final Set<TopicPartition> committedPartitions = new HashSet<>();
+        committedPartitions.add(new TopicPartition(triggerFailedRecord.topic(), triggerFailedRecord.partition()));
+        committedPartitions.add(new TopicPartition(syncRecord.topic(), syncRecord.partition()));
         addCompleteRecordInPolicy(policy, syncRecord);
         assertThat(policy.tryCommit(true))
-                .hasSize(1)
-                .isEqualTo(Collections.singleton(new TopicPartition(syncRecord.topic(), syncRecord.partition())));
+                .hasSize(committedPartitions.size())
+                .containsExactlyInAnyOrderElementsOf(committedPartitions);
 
         verify(mockConsumer, times(1)).commitAsync(any());
         verify(mockConsumer, times(1)).commitSync();

--- a/src/test/java/cn/leancloud/kafka/consumer/CompletedOffsetsTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/CompletedOffsetsTest.java
@@ -1,0 +1,66 @@
+package cn.leancloud.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompletedOffsetsTest {
+    private CompletedOffsets offsets;
+    @Before
+    public void setUp() throws Exception {
+        offsets = new CompletedOffsets(100);
+    }
+
+    @Test
+    public void testNoRecords() {
+        assertThat(offsets.hasOffsetToCommit()).isFalse();
+        assertThat(offsets.hasOffsetToCommit()).isFalse();
+    }
+
+    @Test
+    public void testAddContinuousRecords() {
+        offsets.addCompleteOffset(101);
+        offsets.addCompleteOffset(102);
+        offsets.addCompleteOffset(103);
+
+        assertThat(offsets.hasOffsetToCommit()).isTrue();
+        assertThat(offsets.getOffsetToCommit()).isEqualTo(new OffsetAndMetadata(104));
+    }
+
+    @Test
+    public void testNonContinuousRecords() {
+        offsets.addCompleteOffset(101);
+        offsets.addCompleteOffset(103);
+        offsets.addCompleteOffset(104);
+        offsets.addCompleteOffset(105);
+
+        assertThat(offsets.hasOffsetToCommit()).isTrue();
+        assertThat(offsets.getOffsetToCommit()).isEqualTo(new OffsetAndMetadata(102));
+    }
+
+    @Test
+    public void testNonContinuousRecords2() {
+        offsets.addCompleteOffset(101);
+        offsets.addCompleteOffset(103);
+        offsets.addCompleteOffset(104);
+        offsets.addCompleteOffset(105);
+
+        offsets.addCompleteOffset(102);
+
+        assertThat(offsets.hasOffsetToCommit()).isTrue();
+        assertThat(offsets.getOffsetToCommit()).isEqualTo(new OffsetAndMetadata(106));
+    }
+
+    @Test
+    public void testUpdateCommittedOffset() {
+        offsets.addCompleteOffset(101);
+        offsets.addCompleteOffset(102);
+        offsets.addCompleteOffset(103);
+
+        offsets.updateCommittedOffset(103);
+        assertThat(offsets.hasOffsetToCommit()).isFalse();
+        assertThat(offsets.getOffsetToCommit()).isEqualTo(new OffsetAndMetadata(104));
+    }
+}

--- a/src/test/java/cn/leancloud/kafka/consumer/FetcherTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/FetcherTest.java
@@ -145,7 +145,7 @@ public class FetcherTest {
 
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         assertThat(consumer.subscription()).isEmpty();
         assertThat(consumer.closed()).isTrue();
         assertThat(unsubscribedStatusFuture).isCompletedWithValue(UnsubscribedStatus.ERROR);
@@ -169,7 +169,7 @@ public class FetcherTest {
         fetcher.close();
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         assertThat(consumer.subscription()).isEmpty();
         assertThat(consumer.closed()).isTrue();
         assertThat(unsubscribedStatusFuture).isCompletedWithValue(UnsubscribedStatus.CLOSED);
@@ -202,7 +202,7 @@ public class FetcherTest {
 
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(policy, never()).markCompletedRecord(any());
         verify(policy, never()).tryCommit(true);
         assertThat(unsubscribedStatusFuture).isCompletedWithValue(UnsubscribedStatus.ERROR);
@@ -212,7 +212,7 @@ public class FetcherTest {
     @Test
     public void testExceptionThrownOnShutdown() throws Exception {
         executorService = mock(ExecutorService.class);
-        when(policy.syncPartialCommit()).thenThrow(new RuntimeException("expected testing exception"));
+        when(policy.partialCommitSync()).thenThrow(new RuntimeException("expected testing exception"));
         fetcher = new Fetcher<>(consumer, pollTimeout, consumerRecordHandler, executorService, policy, Duration.ZERO, Duration.ZERO);
         final CompletableFuture<UnsubscribedStatus> unsubscribedStatusFuture = fetcher.unsubscribeStatusFuture();
         fetcherThread = new Thread(fetcher);
@@ -221,7 +221,7 @@ public class FetcherTest {
 
         fetcher.close();
         fetcherThread.join();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         assertThat(consumer.subscription()).isEmpty();
         assertThat(consumer.closed()).isTrue();
         assertThat(unsubscribedStatusFuture).isCompletedWithValue(UnsubscribedStatus.CLOSED);
@@ -242,7 +242,7 @@ public class FetcherTest {
 
         fetcher.close();
         fetcherThread.join();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(mockedConsumer, times(1)).close(100, TimeUnit.NANOSECONDS);
         assertThat(unsubscribedStatusFuture).isCompletedWithValue(UnsubscribedStatus.CLOSED);
     }
@@ -267,7 +267,7 @@ public class FetcherTest {
 
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(policy, times(pendingRecords.size())).markPendingRecord(any());
         verify(policy, times(pendingRecords.size() - 1)).markCompletedRecord(any());
         verify(policy, never()).tryCommit(true);
@@ -294,7 +294,7 @@ public class FetcherTest {
 
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(policy, times(1)).markPendingRecord(eq(defaultTestingRecord));
         verify(policy, never()).markCompletedRecord(any());
         verify(policy, never()).tryCommit(true);
@@ -325,7 +325,7 @@ public class FetcherTest {
         fetcherThread.join();
         assertThat(fetcher.pendingFutures()).isEmpty();
         assertThat(consumer.paused()).isEmpty();
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(policy, times(1)).markPendingRecord(eq(defaultTestingRecord));
         verify(policy, times(1)).markCompletedRecord(defaultTestingRecord);
         verify(policy, atLeastOnce()).tryCommit(anyBoolean());
@@ -380,7 +380,7 @@ public class FetcherTest {
 
         verify(policy, times(pendingRecords.size())).markPendingRecord(any());
         verify(policy, times(pendingRecords.size())).markCompletedRecord(any());
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(consumerRecordHandler, times(pendingRecords.size())).handleRecord(any());
         assertThat(consumer.closed()).isTrue();
         executors.shutdown();
@@ -439,7 +439,7 @@ public class FetcherTest {
 
         verify(policy, times(pendingRecords.size())).markPendingRecord(any());
         verify(policy, times(pendingRecords.size() / 2)).markCompletedRecord(any());
-        verify(policy, times(1)).syncPartialCommit();
+        verify(policy, times(1)).partialCommitSync();
         verify(consumerRecordHandler, times(pendingRecords.size())).handleRecord(any());
         assertThat(consumer.closed()).isTrue();
 

--- a/src/test/java/cn/leancloud/kafka/consumer/PartialSyncCommitPolicyTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/PartialSyncCommitPolicyTest.java
@@ -11,22 +11,25 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 
 import static cn.leancloud.kafka.consumer.TestingUtils.*;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PartialSyncCommitPolicyTest {
     private MockConsumer<Object, Object> consumer;
     private PartialSyncCommitPolicy<Object, Object> policy;
+    private List<TopicPartition> partitions;
+    private List<ConsumerRecord<Object, Object>> pendingRecords;
 
     @Before
     public void setUp() {
         consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         policy = new PartialSyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofSeconds(30));
+        partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
+        assignPartitions(consumer, partitions, 0L);
+        pendingRecords = generateConsumedRecords(consumer, partitions, 2);
     }
 
     @After
@@ -35,31 +38,70 @@ public class PartialSyncCommitPolicyTest {
     }
 
     @Test
-    public void testNoCompleteRecords() {
+    public void testOnlyConsumedRecords() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        generateConsumedRecords(consumer, partitions, 1);
-        assertThat(policy.tryCommit(true)).isEmpty();
+        assertThat(policy.tryCommit(false)).isEmpty();
         for (TopicPartition partition : partitions) {
             assertThat(consumer.committed(partition)).isNull();
         }
+        assertThat(policy.noCompletedOffsets()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
         assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testOnlyPendingRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        addPendingRecordsInPolicy(policy, pendingRecords);
+        assertThat(policy.tryCommit(false)).isEmpty();
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isNull();
+        }
+        assertThat(policy.noTopicOffsetsToCommit()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isNotEmpty();
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testHasCompleteRecordsAndPendingRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        addCompleteRecordsInPolicy(policy, pendingRecords);
+        assertThat(policy.tryCommit(false)).containsExactlyInAnyOrderElementsOf(partitions);
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isEqualTo(new OffsetAndMetadata(3));
+        }
+        assertThat(policy.noCompletedOffsets()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testNoPendingFuturesLeft() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        for (ConsumerRecord<Object, Object> record : pendingRecords) {
+            policy.markPendingRecord(record);
+            policy.markCompletedRecord(record);
+        }
+
+        assertThat(policy.tryCommit(true))
+                .hasSize(partitions.size())
+                .containsExactlyInAnyOrderElementsOf(partitions);
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isEqualTo(new OffsetAndMetadata(3));
+        }
+
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
+        assertThat(policy.completedTopicOffsetsToCommit()).isEmpty();
+        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
     }
 
     @Test
     public void testPartialCommit() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        final List<ConsumerRecord<Object, Object>> pendingRecords = generateConsumedRecords(consumer, partitions, 2);
-        // two records for each partitions
         for (ConsumerRecord<Object, Object> record : pendingRecords) {
             policy.markPendingRecord(record);
-        }
 
-        // complete the first half of the partitions
-        for (ConsumerRecord<Object, Object> record : pendingRecords) {
+            // complete the first half of the partitions
             if (record.partition() < partitions.size() / 2 && record.offset() < 3) {
                 policy.markCompletedRecord(record);
             }
@@ -80,60 +122,8 @@ public class PartialSyncCommitPolicyTest {
             }
         }
 
-        assertThat(policy.completedTopicOffsets()).isEmpty();
+        assertThat(policy.completedTopicOffsetsToCommit()).isEmpty();
+        assertThat(policy.noCompletedOffsets()).isFalse();
         assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
-    }
-
-    @Test
-    public void testNoPendingFuturesLeft() {
-        final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        // two records for each partitions
-        final List<ConsumerRecord<Object, Object>> pendingRecords = generateConsumedRecords(consumer, partitions,2);
-        for (ConsumerRecord<Object, Object> record : pendingRecords) {
-            policy.markPendingRecord(record);
-            policy.markCompletedRecord(record);
-        }
-
-        assertThat(policy.tryCommit(true))
-                .hasSize(partitions.size())
-                .containsExactlyInAnyOrderElementsOf(partitions);
-        for (TopicPartition partition : partitions) {
-            assertThat(consumer.committed(partition)).isEqualTo(new OffsetAndMetadata(3));
-        }
-
-        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
-        assertThat(policy.completedTopicOffsets()).isEmpty();
-        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
-    }
-
-    @Test
-    public void testRecommit() throws Exception{
-        policy = new PartialSyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofMillis(200));
-        long nextRecommitNanos = policy.nextRecommitNanos();
-        assignPartitions(consumer, toPartitions(range(0, 30).boxed().collect(toList())), 0L);
-
-        final List<ConsumerRecord<Object, Object>> prevRecords = generateConsumedRecords(consumer, toPartitions(range(0, 10).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> previousCommitOffsets = buildCommitOffsets(prevRecords);
-        addCompleteRecordsInPolicy(policy, prevRecords);
-        assertThat(policy.tryCommit(true))
-                .containsExactlyInAnyOrderElementsOf(toPartitions(range(0, 10).boxed().collect(toList())));
-        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
-
-        Thread.sleep(200);
-        nextRecommitNanos = policy.nextRecommitNanos();
-        final List<ConsumerRecord<Object, Object>> newRecords = generateConsumedRecords(consumer, toPartitions(range(10, 20).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> newCommitOffsets = buildCommitOffsets(newRecords);
-        newCommitOffsets.putAll(previousCommitOffsets);
-
-        addCompleteRecordsInPolicy(policy, newRecords);
-        assertThat(policy.tryCommit(false))
-                .containsExactlyInAnyOrderElementsOf(toPartitions(range(10, 20).boxed().collect(toList())));
-
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : newCommitOffsets.entrySet()) {
-            assertThat(consumer.committed(entry.getKey())).isEqualTo(entry.getValue());
-        }
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
     }
 }

--- a/src/test/java/cn/leancloud/kafka/consumer/SyncCommitPolicyTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/SyncCommitPolicyTest.java
@@ -11,22 +11,25 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 
 import static cn.leancloud.kafka.consumer.TestingUtils.*;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SyncCommitPolicyTest {
     private MockConsumer<Object, Object> consumer;
     private SyncCommitPolicy<Object, Object> policy;
+    private List<TopicPartition> partitions;
+    private List<ConsumerRecord<Object, Object>> pendingRecords;
 
     @Before
     public void setUp() {
         consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         policy = new SyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofHours(1));
+        partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
+        assignPartitions(consumer, partitions, 0L);
+        pendingRecords = generateConsumedRecords(consumer, partitions);
     }
 
     @After
@@ -35,75 +38,53 @@ public class SyncCommitPolicyTest {
     }
 
     @Test
-    public void testHavePendingRecords() {
+    public void testOnlyConsumedRecords() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        final List<ConsumerRecord<Object, Object>> pendingRecords = generateConsumedRecords(consumer, partitions);
+        assertThat(policy.tryCommit(true)).isEmpty();
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isNull();
+        }
+        assertThat(policy.noCompletedOffsets()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testOnlyPendingRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
+        addPendingRecordsInPolicy(policy, pendingRecords);
+        assertThat(policy.tryCommit(false)).isEmpty();
+        for (TopicPartition partition : partitions) {
+            assertThat(consumer.committed(partition)).isNull();
+        }
+        assertThat(policy.noTopicOffsetsToCommit()).isTrue();
+        assertThat(policy.topicOffsetHighWaterMark()).hasSize(partitions.size());
+        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
+    }
+
+    @Test
+    public void testHasCompleteRecordsAndPendingRecords() {
+        final long nextRecommitNanos = policy.nextRecommitNanos();
         addCompleteRecordsInPolicy(policy, pendingRecords);
         assertThat(policy.tryCommit(false)).isEmpty();
         for (TopicPartition partition : partitions) {
             assertThat(consumer.committed(partition)).isNull();
         }
-        assertThat(policy.completedTopicOffsets()).isNotEmpty();
+        assertThat(policy.noCompletedOffsets()).isFalse();
         assertThat(policy.topicOffsetHighWaterMark()).isNotEmpty();
-        assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
-    }
-
-    @Test
-    public void testNoCompleteRecords() {
-        final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        generateConsumedRecords(consumer, partitions);
-        assertThat(policy.tryCommit(true)).isEmpty();
-        for (TopicPartition partition : partitions) {
-            assertThat(consumer.committed(partition)).isNull();
-        }
         assertThat(policy.nextRecommitNanos()).isEqualTo(nextRecommitNanos);
     }
 
     @Test
     public void testTryCommitAll() {
         final long nextRecommitNanos = policy.nextRecommitNanos();
-        final List<TopicPartition> partitions = toPartitions(IntStream.range(0, 30).boxed().collect(toList()));
-        assignPartitions(consumer, partitions, 0L);
-        final List<ConsumerRecord<Object, Object>> pendingRecords = generateConsumedRecords(consumer, partitions);
         addCompleteRecordsInPolicy(policy, pendingRecords);
         assertThat(policy.tryCommit(true)).containsExactlyInAnyOrderElementsOf(partitions);
         for (TopicPartition partition : partitions) {
             assertThat(consumer.committed(partition)).isEqualTo(new OffsetAndMetadata(2));
         }
-        assertThat(policy.completedTopicOffsets()).isEmpty();
+        assertThat(policy.noCompletedOffsets()).isTrue();
         assertThat(policy.topicOffsetHighWaterMark()).isEmpty();
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-    }
-
-    @Test
-    public void testRecommit() throws Exception{
-        policy = new SyncCommitPolicy<>(consumer, Duration.ZERO, 3, Duration.ofMillis(200));
-        long nextRecommitNanos = policy.nextRecommitNanos();
-        assignPartitions(consumer, toPartitions(range(0, 30).boxed().collect(toList())), 0L);
-
-        final List<ConsumerRecord<Object, Object>> prevRecords = generateConsumedRecords(consumer, toPartitions(range(0, 10).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> previousCommitOffsets = buildCommitOffsets(prevRecords);
-        addCompleteRecordsInPolicy(policy, prevRecords);
-        assertThat(policy.tryCommit(true))
-                .containsExactlyInAnyOrderElementsOf(toPartitions(range(0, 10).boxed().collect(toList())));
-        assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
-
-        Thread.sleep(200);
-        nextRecommitNanos = policy.nextRecommitNanos();
-        final List<ConsumerRecord<Object, Object>> newRecords = generateConsumedRecords(consumer, toPartitions(range(10, 20).boxed().collect(toList())), 10);
-        final Map<TopicPartition, OffsetAndMetadata> newCommitOffsets = buildCommitOffsets(newRecords);
-        newCommitOffsets.putAll(previousCommitOffsets);
-
-        addCompleteRecordsInPolicy(policy, newRecords);
-        assertThat(policy.tryCommit(false)).isEmpty();
-
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : newCommitOffsets.entrySet()) {
-            assertThat(consumer.committed(entry.getKey())).isEqualTo(entry.getValue());
-        }
         assertThat(policy.nextRecommitNanos()).isGreaterThan(nextRecommitNanos);
     }
 }

--- a/src/test/java/cn/leancloud/kafka/consumer/integration/JoinLeaveGroupTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/integration/JoinLeaveGroupTest.java
@@ -27,7 +27,7 @@ class JoinLeaveGroupTest implements IntegrationTest{
 
         final List<LcKafkaConsumer<Integer, String>> postJoinConsumers = new ArrayList<>();
         for (int i = 0; i < 5; ++i) {
-            final LcKafkaConsumer<Integer, String> consumer = cxt.factory().buildConsumer("consumer-" + i, statistics);
+            final LcKafkaConsumer<Integer, String> consumer = cxt.factory().buildConsumer(name() + "-" + i, statistics);
             consumer.subscribe(Collections.singletonList(cxt.topic()));
             postJoinConsumers.add(consumer);
             Thread.sleep(ThreadLocalRandom.current().nextInt(1000, 5000));

--- a/src/test/java/cn/leancloud/kafka/consumer/integration/TwoConsumerTest.java
+++ b/src/test/java/cn/leancloud/kafka/consumer/integration/TwoConsumerTest.java
@@ -16,8 +16,8 @@ class TwoConsumerTest implements IntegrationTest{
 
     @Override
     public void runTest(TestContext context, TestStatistics statistics) throws Exception {
-        final LcKafkaConsumer<Integer, String> consumer = context.factory().buildConsumer("consumer-1", statistics);
-        final LcKafkaConsumer<Integer, String> consumer2 = context.factory().buildConsumer("consumer-2", statistics);
+        final LcKafkaConsumer<Integer, String> consumer = context.factory().buildConsumer(name() + "-consumer-1", statistics);
+        final LcKafkaConsumer<Integer, String> consumer2 = context.factory().buildConsumer(name() + "-consumer-2", statistics);
         consumer.subscribe(Collections.singletonList(context.topic()));
         consumer2.subscribe(Collections.singletonList(context.topic()));
         final int totalSent = context.producer().startFixedDurationTest(context.topic(), Duration.ofSeconds(10)).get();


### PR DESCRIPTION
For partial commit policy with thread pool, when it fetched records from broker, it dispatches all records to threads in the pool to process. The finishing time for these records may out of order. When doing a partial commit, we should only commit those offset of records in order and leaving those out of order ones for next partial commit. Such as a partition has record offsets from 1 to 5, if record 1, 2, 5 is finished, we can only commit offset to the second record (that would be 3 for offset of record plus 1), not the fifth. But on the contrary, partial commit policy in previous versions will commit offset to 5 even though 3 and 4 have not finished.